### PR TITLE
feat: support controlling website configuration during deployment

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,6 +6,7 @@ const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
 const docsDir = process.env.DOCS_DIR || 'docs';
+const domain = process.env.DOMAIN || 'https://thin-edge.github.io';
 const baseUrl = process.env.BASE_URL || '/';
 
 /** @type {import('@docusaurus/types').Config} */
@@ -18,7 +19,7 @@ const config = {
   },
   themes: ['@docusaurus/theme-mermaid'],
   // Set the production url of your site here
-  url: 'https://thin-edge.github.io',
+  url: domain,
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,6 +6,7 @@ const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
 const docsDir = process.env.DOCS_DIR || 'docs';
+const baseUrl = process.env.BASE_URL || '/';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -20,7 +21,7 @@ const config = {
   url: 'https://thin-edge.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
To allow deploying the website to different domains, it is useful to be able to control the url (domain) and baseUrl via environment variables when building the docusaurus project.

**Example**

The project can be built for different domains (e.g. to host on a fork) by setting the following environment variables, then building the project.

```sh
export DOMAIN=https://reubenmiller.github.io
export BASE_URL=/thin-edge.io/
yarn build
```

The built project files can then be deployed to the matching hosting service.