### PR TITLE
feat: support 'edit this page' links on the next version only

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -54,10 +54,11 @@ const config = {
           path: fs.realpathSync(docsDir),
           // Should the unreleased docs be published
           includeCurrentVersion: includeCurrentVersion === "true",
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
-          //editUrl:
-           // 'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+          // Enable "edit this page" links for only the current/next version
+          editUrl: ({
+            version,
+            docPath,
+          }) => version == 'current' ? `https://github.com/thin-edge/thin-edge.io/edit/main/docs/src/${docPath}` : undefined,
         },
         blog: false, // Optional: disable the blog plugin
         theme: {


### PR DESCRIPTION
Add `edit this page` links on pages shown in the current release to encourage easier edits/contributions from users.

**Example**

<img width="870" alt="image" src="https://github.com/thin-edge/tedge-docs/assets/3029781/e5aa9b02-b19d-44e7-ad16-bcae35f0857c">
