### PR TITLE
feat: add remark plugin to support running a command to generate code block contents

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,6 +4,7 @@
 const fs = require('fs');
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
+const remarkCmdRun = require('./src/remark/cmd-run');
 
 const docsDir = process.env.DOCS_DIR || 'docs';
 const domain = process.env.DOMAIN || 'https://thin-edge.github.io';
@@ -59,6 +60,9 @@ const config = {
             version,
             docPath,
           }) => version == 'current' ? `https://github.com/thin-edge/thin-edge.io/edit/main/docs/src/${docPath}` : undefined,
+          beforeDefaultRemarkPlugins: [
+            [remarkCmdRun, {showErrors: true, strict: false}],
+          ],
         },
         blog: false, // Optional: disable the blog plugin
         theme: {

--- a/src/remark/cmd-run.js
+++ b/src/remark/cmd-run.js
@@ -1,0 +1,70 @@
+/*
+  Convert a code block with the command="<command>" property where the code block contents
+  replaced with the output of the command.
+
+  The plugin will only activate if the code block use the syntax set to `run` and a `command=""` property is set.
+
+  Example
+
+  The following markdown will get converted from:
+
+  ```run title="List items in a directory" command="ls -l" lang="sh"
+  total 1
+  -rw-r--r--@   1 tedge  staff     209 Jun 22 11:13 Dockerfile
+  ```
+
+  to:
+
+  ```sh title="List items in a directory"
+  total 3
+  -rw-r--r--@   1 tedge  staff     209 Jun 22 11:13 Dockerfile
+  -rw-r--r--    1 tedge  staff    2290 Jun 30 22:45 README.md
+  -rw-r--r--@   1 tedge  staff      89 Jun 22 11:13 babel.config.js
+  ```
+
+  Note:
+  * The code block
+*/
+const { execSync } = require('child_process');
+const visit = require('unist-util-visit');
+const metaUtils = require('./meta');
+
+const plugin = (options) => {
+  const transformer = async (ast) => {
+    visit(ast, 'code', (node) => {
+      if (node.lang != 'run' || !node.value) return;
+
+      const meta = metaUtils.fromString(node.meta || '');
+      if (!meta.command) return;
+
+      // execute command and use the result in the code block
+      try {
+        const output = execSync(meta.command, {
+          timeout: 2000,
+        });
+
+        node.value = output.toString('utf8').trimEnd();
+
+        // remove meta info related to this plugin
+        node.meta = metaUtils.toString(meta, ['command', 'lang']);
+        node.lang = meta.lang || '';
+      } catch (error) {
+        console.warn('Failed to run command', {
+          meta,
+          error,
+        });
+
+        if (options.showErrors) {
+          node.value = `${error}`.trimEnd();
+        }
+
+        if (options.strict) {
+          throw error;
+        }
+      }
+    });
+  };
+  return transformer;
+};
+
+module.exports = plugin;

--- a/src/remark/meta.js
+++ b/src/remark/meta.js
@@ -1,0 +1,83 @@
+/*
+  Helper functions to parse meta data associated to a node
+*/
+
+// Process the meta key
+function processKey(value, start) {
+  let c = '';
+  let index = start;
+
+  while (index < value.length) {
+    c = value.at(index);
+    if (c == '=') {
+      break;
+    }
+    index++;
+  }
+  return { value: value.substring(start, index), index: index + 1 };
+}
+
+// Process the meta value
+function processValue(value, start) {
+  let c = '';
+  let index = start;
+  let inQuote = false;
+
+  while (index < value.length) {
+    c = value.at(index);
+    if (c == '"') {
+      inQuote = !inQuote
+    }
+    if (c == ' ' && !inQuote) {
+      break;
+    }
+    index++;
+  }
+  let propValue = value.substring(start, index);
+
+  // Strip surrounding quotes
+  if (propValue.startsWith('"') && propValue.endsWith('"')) {
+    propValue = propValue.substring(1, propValue.length - 1);
+  }
+  return { value: propValue, index: index + 1 };
+}
+
+/*
+  Convert meta data in string format to an object (for easier parsing)
+*/
+function fromString(raw) {
+  let index = 0;
+  let current = raw;
+  let meta = {};
+
+  while (index < current.length) {
+    const metaKey = processKey(current, index);
+    index = metaKey.index;
+
+    const metaValue = processValue(current, index);
+    index = metaValue.index;
+
+    if (metaKey.value) {
+      meta[metaKey.value] = metaValue.value;
+    }
+  }
+  return meta;
+}
+
+/*
+  Convert meta data object to a string
+*/
+function toString(meta, ignore = []) {
+  let props = [];
+  for (const [key, value] of Object.entries(meta)) {
+    if (!ignore.includes(key)) {
+      props.push(`${key}=${JSON.stringify(value)}`);
+    }
+  }
+  return props.join(' ');
+}
+
+module.exports = {
+  toString,
+  fromString,
+};


### PR DESCRIPTION
Convert a code block with the command="<command>" property where the code block contents
replaced with the output of the command.

The plugin will only activate if the code block use the syntax set to `run` and a `command=""` property is set.

**Example**

The following markdown will get converted from:

````
```run title="List items in a directory" command="ls -l" lang="sh"
total 1
-rw-r--r--@   1 tedge  staff     209 Jun 22 11:13 Dockerfile
```
````

to:

````
```sh title="List items in a directory"
total 3
-rw-r--r--@   1 tedge  staff     209 Jun 22 11:13 Dockerfile
-rw-r--r--    1 tedge  staff    2290 Jun 30 22:45 README.md
-rw-r--r--@   1 tedge  staff      89 Jun 22 11:13 babel.config.js
```
````
Where the `command="ls -l"` is executed and the output is used as the code block's contents.

**Notes**

* You can include an example output in the markdown in cases where the command does not run successfully (only supported when the plugin option is set to `strict: false`). This is also useful because the markdown document is more readable directly in github as the user can see an example of the output without having to run the plugin.