### PR TITLE
feat: add `te2mqtt` directive to tedge mqtt pub/sub commands as tabs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const remarkCmdRun = require('./src/remark/cmd-run');
+const remarkMqttCodeBlock = require('./src/remark/mqtt-codeblock');
 
 const docsDir = process.env.DOCS_DIR || 'docs';
 const domain = process.env.DOMAIN || 'https://thin-edge.github.io';
@@ -62,6 +63,15 @@ const config = {
           }) => version == 'current' ? `https://github.com/thin-edge/thin-edge.io/edit/main/docs/src/${docPath}` : undefined,
           beforeDefaultRemarkPlugins: [
             [remarkCmdRun, {showErrors: true, strict: false}],
+          ],
+          remarkPlugins: [
+            [
+              remarkMqttCodeBlock,
+              {
+                sync: true,
+                converters: ['tedge', 'mosquitto', 'mqtt'],
+              }
+            ],
           ],
         },
         blog: false, // Optional: disable the blog plugin

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "shell-quote": "^1.8.1"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.4.1",

--- a/src/remark/mqtt-codeblock.js
+++ b/src/remark/mqtt-codeblock.js
@@ -1,0 +1,145 @@
+
+const visit = require('unist-util-visit');
+const is = require('unist-util-is');
+const { convertToMosquitto, prettify, parseTedgeCommand } = require('./tedge');
+
+const importNodes = [
+  {
+    type: "import",
+    value: "import Tabs from '@theme/Tabs';",
+  },
+  {
+    type: "import",
+    value: "import TabItem from '@theme/TabItem';",
+  },
+];
+
+function createCodeExample(code, converter) {
+  if (converter === 'mosquitto') {
+    return [
+      {
+        type: 'code',
+        lang: 'sh',
+        meta: '',
+        value: convertToMosquitto(code),
+      }
+    ];
+  }
+  if (converter === 'mqtt') {
+    const api = parseTedgeCommand(code);
+    if (api.action == 'pub') {
+      const title = [];
+      if (api.retain) {
+        title.push(`retain=${api.retain}`);
+      }
+      if (api.qos) {
+        title.push(`qos=${api.qos}`);
+      }
+      return [
+        {
+          type: 'code',
+          lang: 'sh',
+          meta: `title="Publish topic : ${title.join(' ')}"`,
+          value: prettify(api.topic),
+        },
+        {
+          type: 'code',
+          lang: 'sh',
+          meta: `title="Payload"`,
+          value: prettify(api.payload),
+        }
+      ];
+    }
+    return [
+      {
+        type: 'code',
+        lang: 'sh',
+        meta: `title="Subscribe: ${api.topic}   retain=${api.retain}"`,
+        value: prettify(api.payload),
+      }
+    ];
+  }
+
+  // default (no conversion)
+  return [
+    {
+      type: 'code',
+      lang: 'sh',
+      meta: '',
+      value: code,
+    }
+  ];
+}
+
+function collectCodeNodes(code, converters = []) {
+  const tabNodes = [];
+  converters.forEach(converter => {
+    const nodes = createCodeExample(code, converter);
+    tabNodes.push([nodes, { label: converter, value: converter }]);
+  });
+  return tabNodes;
+}
+
+function formatTabs(tabNodes, { groupId, labels, sync }) {
+  function formatTabItem(nodes, meta) {
+    const lang = nodes[0].lang;
+    const label = meta.label ?? labels.get(lang);
+    const value = meta.label?.toLowerCase() ?? lang;
+
+    return [
+      {
+        type: "jsx",
+        value: `<TabItem value="${value}"${label ? ` label="${label}"` : ""}>`,
+      },
+      ...nodes,
+      {
+        type: "jsx",
+        value: "</TabItem>",
+      },
+    ];
+  }
+
+  return [
+    {
+      type: "jsx",
+      value: `<Tabs${sync ? ` groupId="${groupId}"` : ""}>`,
+    },
+    ...tabNodes.map(([nodes, meta]) => formatTabItem(nodes, meta)),
+    {
+      type: "jsx",
+      value: "</Tabs>",
+    },
+  ].flat();
+}
+
+const plugin = (options = {}) => {
+  const { sync = true, groupId = 'te2mqtt', converters = ['tedge', 'mosquitto', 'mqtt'] } = options;
+  return (root) => {
+    let transformed = false;
+    let includesImportTabs = false;
+
+    visit(root, ['code', 'import'], (node, index, parent) => {
+      if (is(node, 'import') && node.value.includes('@theme/Tabs')) {
+        includesImportTabs = true;
+        return;
+      }
+
+      if (is(node, 'code') && node.meta === 'te2mqtt') {
+        const code = node.value;
+        const codeBlocks = collectCodeNodes(code, converters);
+        const tabs = formatTabs(codeBlocks, {
+          sync,
+          groupId,
+        });
+        parent.children.splice(index, 1, ...tabs);
+        transformed = true;
+      }
+    });
+
+    if (transformed && !includesImportTabs) {
+      root.children.unshift(...importNodes);
+    }
+  };
+};
+
+module.exports = plugin;

--- a/src/remark/tedge.js
+++ b/src/remark/tedge.js
@@ -1,0 +1,104 @@
+/*
+  Helper functions to parse meta data associated to a node
+*/
+
+const parse = require('shell-quote/parse');
+
+const MQTT_PUB = 'pub';
+const MQTT_SUB = 'sub';
+
+function parseTedgeCommand(code) {
+  const api = {
+    action: MQTT_PUB,
+    topic: '',
+    payload: '',
+    retain: '',
+    qos: '',
+  };
+
+  args = parse(code);
+  const positionalArgs = [];
+
+  let i = 3;
+  while (i < args.length) {
+    if (args[i] == '-r' || args[i] == '--retain') {
+      api.retain = true;
+    } else if (args[i] == '-q' || args[i] == '--qos') {
+      i++;
+      if (i < args.length) {
+        api.qos = args[i];
+      }
+    } else {
+      positionalArgs.push(args[i]);
+    }
+    i++
+  }
+
+  if (code.startsWith('tedge mqtt sub')) {
+    api.action = MQTT_SUB;
+    if (positionalArgs.length > 0) {
+      api.topic = positionalArgs[0];
+    }
+  } else if (code.startsWith('tedge mqtt pub')) {
+    api.action = MQTT_PUB;
+    if (positionalArgs.length > 0) {
+      api.topic = positionalArgs[0];
+    }
+    if (positionalArgs.length > 1) {
+      api.payload = positionalArgs[1];
+    }
+  } else {
+    api.action = '';
+  }
+  return api;
+}
+
+/*
+Convert a tedge mqtt sub|pub command to the equivalent mosquitto command
+*/
+function convertToMosquitto(code) {
+  const api = parseTedgeCommand(code);
+  if (api.action == MQTT_SUB) {
+      return toMosquittoSubCli(api);
+  }
+  return toMosquittoPubCli(api);
+}
+
+function toMosquittoPubCli(options) {
+  const command = [
+      'mosquitto_pub',
+  ];
+
+  if (options.retain) {
+      command.push('-r');
+  }
+  if (options.qos) {
+      command.push('-q', options.qos);
+  }
+  command.push('-t', `'${options.topic}'`, '-m', `'${options.payload}'`);
+  return command.join(' ');
+}
+
+function toMosquittoSubCli(options) {
+  const command = [
+      'mosquitto_sub',
+      '-t', `'${options.topic}'`,
+  ];
+  return command.join(' ');
+}
+
+function prettify(payload) {
+  try {
+    const jsonText = JSON.parse(payload);
+    return JSON.stringify(jsonText, null, '  ');
+  } catch (e) {
+    // don't error on non-json body, just return it as is
+    return payload;
+  }
+}
+
+module.exports = {
+  convertToMosquitto,
+  parseTedgeCommand,
+  prettify,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7101,7 +7101,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@^1.7.3:
+shell-quote@^1.7.3, shell-quote@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
   integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==


### PR DESCRIPTION
Add `te2mqtt` directive to a code block which uses a `tedge mqtt` command which will result in displaying the mqtt information in various formats, e.g. mosquitto_sub/pub cli and generic mqtt info.

**Example**

The following code block in markdown will be converted to tabs by the `te2mqtt` directive. Each tab will show the equivalent command using different cli tools.

````
```sh te2mqtt
tedge mqtt pub tedge/health/tedge-mapper-c8y '{"status":"up","type":"thin-edge.io"}' -q 2 -r
```
````

<img width="1090" alt="image" src="https://github.com/thin-edge/tedge-docs/assets/3029781/cbfa0670-e014-4994-a50a-f54cf314b651">
