### PR TITLE
fix: mqtt code block formatting of complex commands

### DIFF
--- a/src/remark/mqtt-codeblock.js
+++ b/src/remark/mqtt-codeblock.js
@@ -39,14 +39,14 @@ function createCodeExample(code, converter) {
         {
           type: 'code',
           lang: 'sh',
-          meta: `title="Publish topic : ${title.join(' ')}"`,
+          meta: title.length > 0 ? `title="Publish topic: ${title.join(', ')}"` : `title="Publish topic"`,
           value: prettify(api.topic),
         },
         {
           type: 'code',
           lang: 'sh',
           meta: `title="Payload"`,
-          value: prettify(api.payload),
+          value: prettify(api.payload || '<<empty>>'),
         }
       ];
     }
@@ -54,8 +54,8 @@ function createCodeExample(code, converter) {
       {
         type: 'code',
         lang: 'sh',
-        meta: `title="Subscribe: ${api.topic}   retain=${api.retain}"`,
-        value: prettify(api.payload),
+        meta: `title="Subscribe: topic"`,
+        value: prettify(api.topic),
       }
     ];
   }


### PR DESCRIPTION
Minor improvements to handle more complex command usage.

* Preserve any additional positional arguments (e.g. `tedge mqtt sub '#' > myfile.txt`)
* Only display meta info (retain, qos) if set
* Display `<<emtpy>>` in payload for mqtt tab if payload is empty so it is more obvious for users that it is meant to be empty