### PR TITLE
fix: ignore cmdrun errors by default as the user can set a default value to use

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -62,7 +62,7 @@ const config = {
             docPath,
           }) => version == 'current' ? `https://github.com/thin-edge/thin-edge.io/edit/main/docs/src/${docPath}` : undefined,
           beforeDefaultRemarkPlugins: [
-            [remarkCmdRun, {showErrors: true, strict: false}],
+            [remarkCmdRun, {showErrors: false, strict: false}],
           ],
           remarkPlugins: [
             [


### PR DESCRIPTION
By default don't show the error output of the command as a sensible default can be provided.

Ideally the build should fail if a codeblock command is not execute successfully, however it is complicated by the fact that multiple versions are now supported, meaning that there will be two sets of the same binaries (one for the previous version and one for the current version). When this problem is solved (e.g. using custom PATH variables when calling the subproces), then the command can fail noisily.