### PR TITLE
feat: support zooming in on images

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -82,18 +82,7 @@ const config = {
     ],
   ],
   plugins: [
-    // function (context, options) {
-    //   return {
-    //     name: 'webpack-configuration-plugin',
-    //     configureWebpack(config, isServer, utils) {
-    //       return {
-    //         resolve: {
-    //           symlinks: false,
-    //         }
-    //       };
-    //     }
-    //   };
-    // },
+    'plugin-image-zoom',
   ],
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@docusaurus/theme-mermaid": "^2.4.1",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
+    "plugin-image-zoom": "flexanalytics/plugin-image-zoom",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5483,6 +5483,11 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
+medium-zoom@^1.0.4:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/medium-zoom/-/medium-zoom-1.0.8.tgz#2bd1fbcf2961fa7b0e318fe284462aa9b8608ed2"
+  integrity sha512-CjFVuFq/IfrdqesAXfg+hzlDKu6A2n80ZIq0Kl9kWjoHh9j1N9Uvk5X0/MmN0hOfm5F9YBswlClhcwnmtwz7gA==
+
 memfs@^3.1.2, memfs@^3.4.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.5.3.tgz#d9b40fe4f8d5788c5f895bda804cd0d9eeee9f3b"
@@ -6012,6 +6017,12 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+plugin-image-zoom@flexanalytics/plugin-image-zoom:
+  version "1.1.0"
+  resolved "https://codeload.github.com/flexanalytics/plugin-image-zoom/tar.gz/3e64669f3c8fb998a556432ca3f56e0f617454f2"
+  dependencies:
+    medium-zoom "^1.0.4"
 
 postcss-calc@^8.2.3:
   version "8.2.4"


### PR DESCRIPTION
Support providing a click-to-zoom option on all images.

The following shows how the images can be imported.

If an image is defined in the markdown you can either provide a link to an image using:

```markdown
![Add new apama project in Software Repository](../../images/apama-plugin/apama-project-c8y-software-repository.png)
```


Or if you want more control of the image (e.g. specifying a default size), then you can use the following snippet in the docs:

```markdown
<p align="center">
    <img
        src={require('../../images/apama-plugin/apama-project-c8y-software-repository.png').default}
        alt="Example banner"
        width="40%"
    />
</p>
```
