### PR TITLE
feat: include mark file when copying versioned info for better traceability

### DIFF
--- a/justfile
+++ b/justfile
@@ -34,12 +34,15 @@ checkout-version version="" branch="":
         TAG="$(git -C ../thin-edge.io_versioned describe --tags $(git -C ../thin-edge.io_versioned rev-list --tags --max-count=1))"
     fi
 
+    SOURCE_REPO_INFO=""
     if [ -n "{{branch}}" ]; then
         echo "Checking out a branch"
         git -C ../thin-edge.io_versioned checkout "{{branch}}"
+        SOURCE_REPO_INFO="$(git -C ../thin-edge.io_versioned describe --always) {{branch}}"
     else
         echo "Checking out a tag"
         git -C ../thin-edge.io_versioned checkout "$TAG" -b "latest"
+        SOURCE_REPO_INFO="$TAG"
     fi
 
     echo "Creating list of versions to be included (only 1 is supported atm)"
@@ -50,6 +53,9 @@ checkout-version version="" branch="":
     rm -rf "./versioned_docs/version-$TAG"
     # Symlinks are not supported here, so we have to copy the files
     cp -R ../thin-edge.io_versioned/docs/src "./versioned_docs/version-$TAG"
+
+    # Store marker info about the source repo so it is easier to trace
+    printf '%s' "$SOURCE_REPO_INFO" > "./versioned_docs/version-$TAG/.version"
 
     echo "Creating versioned sidebars"
     mkdir -p versioned_sidebars


### PR DESCRIPTION
A `.version` file will be stored under the versioned docs file.

Below show an example format when using the following manual version from the main branch.

```sh
just checkout-version 0.11.0 main
```

**output file: tedge-docs/versioned_docs/version-0.11.0/.version**
```
0.11.0-186-gc4caa7d43c main
```