### PR TITLE
fix(chrome): avoid passive events warnings in console by modifying event handlers

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -42,7 +42,10 @@ const config = {
     defaultLocale: 'en',
     locales: ['en'],
   },
-
+  clientModules: [
+    // Prevent chrome warnings: Consider marking event handler as 'passive' to make the page more responsive
+    require.resolve('default-passive-events'),
+  ],
   presets: [
     [
       'classic',

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@docusaurus/theme-mermaid": "^2.4.1",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
+    "default-passive-events": "^2.0.0",
     "plugin-image-zoom": "flexanalytics/plugin-image-zoom",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3922,6 +3922,11 @@ default-gateway@^6.0.3:
   dependencies:
     execa "^5.0.0"
 
+default-passive-events@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/default-passive-events/-/default-passive-events-2.0.0.tgz#79b1aa67becbaab38b718469b5480fef92eda649"
+  integrity sha512-eMtt76GpDVngZQ3ocgvRcNCklUMwID1PaNbCNxfpDXuiOXttSh0HzBbda1HU9SIUsDc02vb7g9+3I5tlqe/qMQ==
+
 defer-to-connect@^1.0.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"


### PR DESCRIPTION
This error is only seen in chrome. Other browsers don't seem to be affected.