### PR TITLE
feat(cmd-run): add option to silence logging of warnings when a command fails

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -65,7 +65,7 @@ const config = {
             docPath,
           }) => version == 'current' ? `https://github.com/thin-edge/thin-edge.io/edit/main/docs/src/${docPath}` : undefined,
           beforeDefaultRemarkPlugins: [
-            [remarkCmdRun, {showErrors: false, strict: false}],
+            [remarkCmdRun, {showErrors: false, strict: false, logErrors: false}],
           ],
           remarkPlugins: [
             [

--- a/src/remark/cmd-run.js
+++ b/src/remark/cmd-run.js
@@ -41,6 +41,11 @@ const plugin = (options) => {
       try {
         const output = execSync(meta.command, {
           timeout: 2000,
+          stdio: [
+            'ignore', // stdin
+            'pipe', // stdout
+            'ignore', // stderr
+          ],
         });
 
         node.value = output.toString('utf8').trimEnd();
@@ -49,10 +54,12 @@ const plugin = (options) => {
         node.meta = metaUtils.toString(meta, ['command', 'lang']);
         node.lang = meta.lang || '';
       } catch (error) {
-        console.warn('Failed to run command', {
-          meta,
-          error,
-        });
+        if (options.logErrors) {
+          console.warn('Failed to run command', {
+            meta,
+            error: `${error}`,
+          });
+        }
 
         if (options.showErrors) {
           node.value = `${error}`.trimEnd();


### PR DESCRIPTION
Add `logErrors` option to silence the cmd-run plugin warnings when a commands does not execute successfully. Default is disabled for now.