### PR TITLE
fix(chrome): add permission policy meta data to prevent chrome warnings

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -170,6 +170,13 @@ const config = {
           name: 'keywords',
           content: 'iot, edge, cumulocity-iot, azure-iot, aws-iot, iot-devices',
         },
+        // Add permissions-policy to prevent chrome warnings
+        // Example: Error with Permissions-Policy header: Origin trial controlled feature not enabled: 'interest-cohort'.
+        // https://github.com/orgs/community/discussions/52356
+        {
+          'http-equiv': 'Permissions-Policy',
+          content: 'interest-cohort=()',
+        },
       ],
       prism: {
         theme: lightCodeTheme,


### PR DESCRIPTION
Prevent warnings like this in the chrome console:

```
Error with Permissions-Policy header: Origin trial controlled feature not enabled: 'interest-cohort'.
```

Fix is discussed [here](https://github.com/orgs/community/discussions/52356).