### PR TITLE
fix(cmd-run): execute command even when the code block has no default value

### DIFF
--- a/src/remark/cmd-run.js
+++ b/src/remark/cmd-run.js
@@ -32,7 +32,7 @@ const metaUtils = require('./meta');
 const plugin = (options) => {
   const transformer = async (ast) => {
     visit(ast, 'code', (node) => {
-      if (node.lang != 'run' || !node.value) return;
+      if (node.lang != 'run') return;
 
       const meta = metaUtils.fromString(node.meta || '');
       if (!meta.command) return;


### PR DESCRIPTION
Don't ignore empty code blocks.

For example, the following now works:

````
```run command="ls -l"
```
````

Previously, the above command would not have been executed.
