### PR TITLE
feat: add plugins to display generic code blocks as tabs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -87,6 +87,7 @@ const config = {
                 converters: ['tedge', 'mosquitto', 'mqtt'],
               }
             ],
+            require('docusaurus-remark-plugin-tab-blocks'),
           ],
         },
         blog: false, // Optional: disable the blog plugin

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "default-passive-events": "^2.0.0",
+    "docusaurus-remark-plugin-tab-blocks": "^1.3.0",
     "plugin-image-zoom": "flexanalytics/plugin-image-zoom",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4028,6 +4028,14 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
+docusaurus-remark-plugin-tab-blocks@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/docusaurus-remark-plugin-tab-blocks/-/docusaurus-remark-plugin-tab-blocks-1.3.0.tgz#5bcdc92dbb1cd83478cbe6752fbda67e95ace16d"
+  integrity sha512-qVPKuuVD0JiPbOsPiVUzcGl72nFC6kSPCe+Ywn+e4drAnexmbDyIzWvNZsncm6Lp7BNuU1vetr+al5HgwvUjgA==
+  dependencies:
+    unist-util-is "^4.0.0"
+    unist-util-visit "^2.0.0"
+
 dom-converter@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"


### PR DESCRIPTION
Add support for once-off code blocks displayed as a grouped tab.

**Example markdown**

````markdown title="Markdown"
```systemd tab
systemctl status tedge
```

```openrc tab
service tedge status
```
````

**Output**

<img width="1009" alt="image" src="https://github.com/thin-edge/tedge-docs/assets/3029781/0d60e4f1-567a-4a15-8ac7-42214155ed52">
