### PR TITLE
Feat mqtt legacy to new api conversion

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -86,6 +86,10 @@ const config = {
                 sync: true,
                 converters: ['tedge', 'mosquitto', 'mqtt'],
                 formats: ['legacy'],
+                // Group the formats together in the same tabs
+                // e.g. if using 'v1' and 'legacy' formats, both will appear under the 'tedge'
+                // table if grouping is enabled
+                groupTabs: true,
                 // Enable both v1 and legacy examples in code blocks
                 // formats: ['v1', 'legacy'],
               }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -85,6 +85,9 @@ const config = {
               {
                 sync: true,
                 converters: ['tedge', 'mosquitto', 'mqtt'],
+                formats: ['legacy'],
+                // Enable both v1 and legacy examples in code blocks
+                // formats: ['v1', 'legacy'],
               }
             ],
             require('docusaurus-remark-plugin-tab-blocks'),

--- a/src/remark/meta.js
+++ b/src/remark/meta.js
@@ -12,6 +12,10 @@ function processKey(value, start) {
     if (c == '=') {
       break;
     }
+
+    if (c == ' ') {
+      start = index + 1;
+    }
     index++;
   }
   return { value: value.substring(start, index), index: index + 1 };

--- a/src/remark/meta.js
+++ b/src/remark/meta.js
@@ -49,10 +49,10 @@ function processValue(value, start) {
 /*
   Convert meta data in string format to an object (for easier parsing)
 */
-function fromString(raw) {
+function fromString(raw, defaultValues={}) {
   let index = 0;
   let current = raw;
-  let meta = {};
+  let meta = defaultValues;
 
   while (index < current.length) {
     const metaKey = processKey(current, index);
@@ -62,7 +62,12 @@ function fromString(raw) {
     index = metaValue.index;
 
     if (metaKey.value) {
-      meta[metaKey.value] = metaValue.value;
+      try {
+        meta[metaKey.value] = JSON.parse(metaValue.value)
+      } catch (e) {
+        // ignore error and use value as is
+        meta[metaKey.value] = metaValue.value
+      }
     }
   }
   return meta;

--- a/src/remark/mqtt-codeblock.js
+++ b/src/remark/mqtt-codeblock.js
@@ -1,7 +1,8 @@
 
 const visit = require('unist-util-visit');
 const is = require('unist-util-is');
-const { convertToMosquitto, prettify, parseTedgeCommand } = require('./tedge');
+const { convertToMosquitto, prettify, parseTedgeCommand, convertToTedgeCLI } = require('./tedge');
+const metaUtils = require('./meta');
 
 const importNodes = [
   {
@@ -14,19 +15,20 @@ const importNodes = [
   },
 ];
 
-function createCodeExample(code, converter) {
+function createCodeExample(code, converter, format='legacy') {
+  const api = parseTedgeCommand(code, format, false);
+
   if (converter === 'mosquitto') {
     return [
       {
         type: 'code',
         lang: 'sh',
         meta: '',
-        value: convertToMosquitto(code),
+        value: convertToMosquitto(api),
       }
     ];
   }
   if (converter === 'mqtt') {
-    const api = parseTedgeCommand(code);
     if (api.action == 'pub') {
       const title = [];
       if (api.retain) {
@@ -66,16 +68,30 @@ function createCodeExample(code, converter) {
       type: 'code',
       lang: 'sh',
       meta: '',
-      value: code,
+      value: convertToTedgeCLI(api),
     }
   ];
 }
 
-function collectCodeNodes(code, converters = []) {
+function collectCodeNodes(code, converters = [], formats = []) {
   const tabNodes = [];
-  converters.forEach(converter => {
-    const nodes = createCodeExample(code, converter);
-    tabNodes.push([nodes, { label: converter, value: converter }]);
+
+  if (formats.length == 0) {
+    formats.push('legacy');
+  }
+
+  const formatLabel = (name, format) => {
+    if (formats.length > 1) {
+      return `${name} (${format})`;
+    }
+    return name;
+  };
+
+  formats.forEach(format => {
+    converters.forEach(converter => {
+      const nodes = createCodeExample(code, converter, format);
+      tabNodes.push([nodes, { label: formatLabel(converter, format), value: converter }]);
+    });
   });
   return tabNodes;
 }
@@ -113,7 +129,7 @@ function formatTabs(tabNodes, { groupId, labels, sync }) {
 }
 
 const plugin = (options = {}) => {
-  const { sync = true, groupId = 'te2mqtt', converters = ['tedge', 'mosquitto', 'mqtt'] } = options;
+  const { sync = true, groupId = 'te2mqtt', converters = ['tedge', 'mosquitto', 'mqtt'], formats = ['legacy', 'v1'] } = options;
   return (root) => {
     let transformed = false;
     let includesImportTabs = false;
@@ -124,9 +140,18 @@ const plugin = (options = {}) => {
         return;
       }
 
-      if (is(node, 'code') && node.meta === 'te2mqtt') {
+      if (is(node, 'code') && `${node.meta}`.includes('te2mqtt')) {
+        const codeOptions = metaUtils.fromString(node.meta);
+
+        let instanceFormats = formats;
+        if (node.meta != 'te2mqtt') {
+          if (codeOptions.formats) {
+            instanceFormats = codeOptions.formats.split(',');
+          }
+        }
+
         const code = node.value;
-        const codeBlocks = collectCodeNodes(code, converters);
+        const codeBlocks = collectCodeNodes(code, converters, instanceFormats);
         const tabs = formatTabs(codeBlocks, {
           sync,
           groupId,


### PR DESCRIPTION
Support extending the `te2mqtt` Tedge MQTT code block example to display multiple tedge api formats (e.g. `te/` and tedge/` apis).

This is a non-breaking change. The defaults have been set to render the MQTT code block examples exactly how they were done before. Once the new MQTT api is ready, then the features can be activated by default (or slowly opted in per code block).

## Feature: Convert legacy api to new api

Support automatically converting the legacy examples to new examples without code changes. This supports a much smoother transition that the docs can be updated to use the new api, and convert back to the old api using a docusaurus configuration option (or vice versa).

The user can control which formats are displayed by either setting the global `formats` array in the `docusaurus.config.js` file, or on individual code blocks which use the `te2mqtt` directive. An example is shown below.

````markdown
```sh te2mqtt formats=legacy,v1
tedge mqtt pub tedge/alarms/major/temp_hi_hi/child01 '{"text": "Temperature Hi Hi"}'
```
````

## Feature: Grouping different mqtt example formats (e.g. legacy and new)

The legacy api to new api feature allows the possibility to display both the legacy and new api in the one code block (only only requiring the doc writer to only specify one). A `groupTabs` option is added as a global config as well as supporting being set on individual code blocks.

````markdown
```sh te2mqtt formats=legacy,v1 groupTabs=true
tedge mqtt pub tedge/alarms/major/temp_hi_hi/child01 '{"text": "Temperature Hi Hi"}'
```
````

**Tabs grouped by format**

<img width="732" alt="image" src="https://github.com/thin-edge/tedge-docs/assets/3029781/46cb9886-4f4d-48b6-9687-f34733c3fcf4">

**Ungrouped tabs**

<img width="741" alt="image" src="https://github.com/thin-edge/tedge-docs/assets/3029781/41794b67-eb6a-4f1d-9a12-63efbc76bc15">
