### PR TITLE
fix(examples): backport the fix to invalid json examples (missing trailing comma)

### DIFF
--- a/versioned_docs/version-0.11.0/references/data-model.md
+++ b/versioned_docs/version-0.11.0/references/data-model.md
@@ -125,7 +125,7 @@ tedge/events/<event-type>/<child-id>
 {
   // example of an event
   "text": "A user just logged in",     // 'text' message of that event
-  "time": "2021-01-01T05:30:45+00:00"  // optional 'timestamp' of that event
+  "time": "2021-01-01T05:30:45+00:00", // optional 'timestamp' of that event
   "someOtherCustomFragment": {         // optional 'custom fragments'
     "nested": {
       "value": "extra info"

--- a/versioned_docs/version-0.11.0/understand/thin-edge-json.md
+++ b/versioned_docs/version-0.11.0/understand/thin-edge-json.md
@@ -179,7 +179,7 @@ For instance:
 ```sh te2mqtt
 tedge mqtt pub tedge/events/login '{
   "text": "A user just logged in",
-  "time": "2021-01-01T05:30:45+00:00"
+  "time": "2021-01-01T05:30:45+00:00",
   "someOtherCustomFragment": {
     "nested": {
       "value": "extra info"


### PR DESCRIPTION
The backport is required to avoid any possible conversion errors in the new changes to the mqtt code block features (https://github.com/thin-edge/tedge-docs/pull/36), namely the pretty printing functionality. Invalid json would cause an error in the pretty printing of the mqtt payload.