### PR TITLE
feat(te2mqtt): Use strong headers for the different api sections in the generic mqtt tab

### DIFF
--- a/src/remark/mqtt-codeblock.js
+++ b/src/remark/mqtt-codeblock.js
@@ -109,7 +109,7 @@ function collectCodeNodes(code, converters = [], formats = [], groupTabs = false
       if (converter == 'mqtt') {
         nodes.push({
           type: "jsx",
-          value: `<p>API version: ${format}</p>`,
+          value: `<p><strong>API version: ${format}</strong></p>`,
         });
       }
 


### PR DESCRIPTION
Visualisation improvement to ensure the api version (e.g. legacy or v1) are more prominent to the reader.

Example:
<img width="1047" alt="image" src="https://github.com/thin-edge/tedge-docs/assets/3029781/bbea3d4e-56c6-4541-8dee-0298689ca00f">
