### PR TITLE
chore: normalize trailing slashes on doc links to avoid unnecessary redirects

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -27,6 +27,9 @@ const config = {
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl,
 
+  // Normalize trailing slashes
+  trailingSlash: true,
+
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'thin-edge', // Usually your GitHub org/user name.


### PR DESCRIPTION
This settings makes urls links more predictable, though it will force users to use the following convention when using url links:

**Correct example**

````markdown
[example](./start/index.md)
````

**Wrong example**

````markdown
[example](./start/)
````