### PR TITLE
feat: add component to display the list of community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,23 @@ Then verify the result by serving the files:
 ```sh
 just docs-container yarn serve
 ```
+
+## Community Plugin Documentation
+
+The docs also maintain a custom (React) component to display the list of Community Plugins in an interactive way, to make it easier for users to search for plugins which interest them. Each plugin includes a short description, and links to the repository code and the installable package (if applicable).The same plugin list will be visible in all displayed documentation version to increase their visibility to users.
+
+### Add or edit a plugin
+
+The list of plugins is sourced via a single [typescript file](./src/data/plugins.tsx) which makes it easier to maintain and keep consistent across all plugins.
+
+To add or edit a plugin use the following procedure:
+
+1. Fork the repo
+2. Create a new branch with a name relevant to your change
+3. Edit the [typescript file](./src/data/plugins.tsx) file and add the plugin to the array
+
+    **Notes**
+
+    * Add any relevant *tags* to the plugins to allow searching for the plugins based on a fixed list of keywords.
+
+4. Create a PR against the `main` branch of the upstream repository

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,7 +23,7 @@ const config = {
   markdown: {
     mermaid: true,
     // Use preprocessor to replace global variables
-    preprocessor: ({filePath, fileContent}) => {
+    preprocessor: ({ filePath, fileContent }) => {
       return fileContent.replaceAll('{{te}}', '**thin-edge.io**');
     },
   },
@@ -56,10 +56,7 @@ const config = {
     defaultLocale: 'en',
     locales: ['en'],
   },
-  clientModules: [
-    // Prevent chrome warnings: Consider marking event handler as 'passive' to make the page more responsive
-    require.resolve('default-passive-events'),
-  ],
+  clientModules: [],
   headTags: [
     // Add permissions-policy to prevent chrome warnings
     // Example: Error with Permissions-Policy header: Origin trial controlled feature not enabled: 'interest-cohort'.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "prism-react-renderer": "^2.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-markdown": "^9.0.1",
+    "react-select": "^5.8.0",
     "shell-quote": "^1.8.1"
   },
   "devDependencies": {

--- a/src/components/PluginCardsList/index.tsx
+++ b/src/components/PluginCardsList/index.tsx
@@ -1,0 +1,315 @@
+/*
+  Plugin Cards List to display the official list of thin-edge.io plugins
+
+  References
+  * https://github.com/facebook/docusaurus/discussions/7708
+*/
+/* eslint-disable global-require */
+
+import React from 'react';
+import { useState, useEffect } from 'react';
+import Select from 'react-select';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import Heading from '@theme/Heading';
+import Markdown from 'react-markdown';
+import { Plugins, IPlugin } from '../../data/plugins';
+import styles from './styles.module.css';
+
+function getCategories() {
+  const items = {};
+  Plugins.forEach((item) => {
+    if (item.tags) {
+      item.tags.forEach((tag) => (items[tag] = null));
+    }
+  });
+  return Object.keys(items).sort();
+}
+
+function PluginCard({
+  name,
+  sourceUrl = '',
+  packageUrl = '',
+  description = '',
+  tags = [],
+}: IPlugin) {
+  const sourceRepoURL = sourceUrl || `https://github.com/thin-edge/${name}`;
+  const packageRepoURL =
+    packageUrl ||
+    `https://cloudsmith.io/~thinedge/repos/community/packages/?q=name%3A%27%5E${name}%24%27`;
+  return (
+    <div className="col col--12 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className="card__body">
+          <div className="row">
+            <Heading as="h3" id={name}>
+              <span className="padding--sm">📦</span>
+              {name}
+            </Heading>
+          </div>
+          <div
+            className={clsx('row', 'padding-left--md', 'padding-bottom--sm')}
+          >
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="theme-doc-version-badge badge badge--secondary margin--xs"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+          <Markdown>{description}</Markdown>
+        </div>
+        <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={sourceRepoURL}>
+              Go to Repository
+            </Link>
+            <Link className="button button--secondary" to={packageRepoURL}>
+              Go to Package
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface PluginCardsListProps {
+  tags: [];
+}
+
+const options = getCategories().map((item) => ({
+  value: item,
+  label: item,
+}));
+
+interface IKeywordOption {
+  value: string;
+}
+
+interface ISearchOptions {
+  text?: string;
+  categoryOption?: IKeywordOption[];
+}
+
+function ThemedSelect({ options, onChange, defaultValue }) {
+  // Match react-select with the docusaurus theme
+  // Note: This is by no means perfect
+  const colors = {
+    neutral50: 'var(--ifm-font-color-base)',
+    neutral40: 'var(--ifm-font-color-base)',
+    neutral30: 'var(--ifm-font-color-base)',
+    neutral20: 'var(--ifm-color-secondary-darkest)', // control outline
+    neutral10: 'var(--ifm-color-emphasis-500)', // pill background
+    neutral5: 'var(--ifm-font-color-base)',
+    neutral0: 'var(--ifm-card-background-color)', // text background
+    primary25: 'var(--ifm-color-primary)',
+    primary50: 'var(--ifm-color-primary)',
+    primary: 'var(--ifm-color-primary)',
+    background: 'var(--ifm-card-background-color)',
+    text: 'var(--ifm-font-color-base)',
+    textFocused: 'var(--ifm-color-white)',
+    textSelected: 'var(--ifm-color-white)',
+    selected: 'var(--ifm-color-primary)',
+  };
+
+  const customStyles = {
+    control: (styles, {}) => ({
+      ...styles,
+      height: 'var(--docsearch-searchbox-height)',
+    }),
+    input: (styles, {}) => ({
+      ...styles,
+      color: 'var(--ifm-font-color-base)',
+    }),
+    multiValue: (styles, {}) => ({
+      ...styles,
+      color: 'var(--ifm-color-black)',
+      backgroundColor: 'var(--ifm-color-secondary)',
+      borderRadius: 'var(--ifm-badge-border-radius)',
+      fontWeight: 'var(--ifm-font-weight-bold)',
+    }),
+    placeholder: (styles, {}) => ({
+      ...styles,
+      color: 'var(--ifm-color-secondary-darkest)',
+      fontSize: '1.2em',
+    }),
+    option: (styles, { data, isDisabled, isFocused, isSelected }) => {
+      return {
+        ...styles,
+        backgroundColor: isDisabled
+          ? undefined
+          : isSelected
+            ? data.color
+            : isFocused
+              ? colors.selected
+              : undefined,
+        color: isDisabled
+          ? '#ccc'
+          : isSelected
+            ? colors.text
+            : isFocused
+              ? colors.textFocused
+              : colors.text,
+        cursor: isDisabled ? 'not-allowed' : 'default',
+
+        ':active': {
+          ...styles[':active'],
+          backgroundColor: !isDisabled
+            ? isSelected
+              ? data.color
+              : '#ddd'
+            : '#fef',
+        },
+      };
+    },
+  };
+
+  return (
+    <Select
+      theme={(theme) => ({
+        ...theme,
+        colors: {
+          ...theme.colors,
+          ...colors,
+        },
+      })}
+      styles={customStyles}
+      placeholder="Select Keywords..."
+      isMulti
+      defaultValue={defaultValue}
+      onChange={onChange}
+      options={options}
+    />
+  );
+}
+
+export function PluginCardsList({
+  tags = [],
+}: PluginCardsListProps): JSX.Element {
+  const [APIData, setAPIData] = useState<IPlugin[]>([]);
+  useEffect(() => {
+    setAPIData(Plugins);
+  }, []);
+
+  const [filteredResults, setFilteredResults] = useState(Plugins);
+  const [searchInput, setSearchInput] = useState('');
+  const [selectOption, setSelectOption] = useState<IKeywordOption[]>([]);
+
+  const searchItems = ({
+    text = undefined,
+    categoryOption = undefined,
+  }: ISearchOptions) => {
+    if (text != undefined) {
+      setSearchInput(text);
+    }
+
+    if (categoryOption != undefined) {
+      setSelectOption(categoryOption);
+    }
+
+    const filterByCategories = (
+      categoryOption != undefined ? categoryOption : selectOption || []
+    ).map((i) => i.value);
+    const filterByText = text != undefined ? text : searchInput;
+
+    const filteredData = APIData.filter((item) => {
+      if (filterByCategories.length) {
+        if (!item.tags) {
+          return false;
+        }
+        const matchingTags = item.tags.filter((tag) =>
+          filterByCategories.includes(tag),
+        );
+        if (matchingTags.length == 0) {
+          return false;
+        }
+      }
+      return (
+        item.name
+          .toLocaleLowerCase()
+          .includes(filterByText.toLocaleLowerCase()) ||
+        item.description
+          .toLocaleLowerCase()
+          .includes(filterByText.toLocaleLowerCase())
+      );
+    });
+    setFilteredResults(filteredData);
+  };
+
+  return (
+    <div>
+      <div className="padding-bottom--sm">
+        <ThemedSelect
+          defaultValue={selectOption}
+          onChange={(value) => searchItems({ categoryOption: [...value] })}
+          options={options}
+        />
+      </div>
+      <form
+        className={clsx(
+          'DocSearch',
+          styles.pluginForm,
+          styles.pluginTextSearch,
+        )}
+      >
+        <label
+          className="DocSearch-MagnifierLabel"
+          style={{ color: 'var(--ifm-color-emphasis-500)' }}
+        >
+          <svg
+            width="20"
+            height="20"
+            className="DocSearch-Search-Icon"
+            viewBox="0 0 20 20"
+          >
+            <path
+              d="M14.386 14.386l4.0877 4.0877-4.0877-4.0877c-2.9418 2.9419-7.7115 2.9419-10.6533 0-2.9419-2.9418-2.9419-7.7115 0-10.6533 2.9418-2.9419 7.7115-2.9419 10.6533 0 2.9419 2.9418 2.9419 7.7115 0 10.6533z"
+              stroke="currentColor"
+              fill="none"
+              fillRule="evenodd"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            ></path>
+          </svg>
+        </label>
+        <input
+          value={searchInput}
+          className={clsx('DocSearch-Input')}
+          placeholder="Search plugins"
+          onChange={(e) => searchItems({ text: e.target.value })}
+        />
+        {searchInput && (
+          <button
+            onClick={(_e) => searchItems({ text: '' })}
+            type="reset"
+            title="Clear the query"
+            className={styles.searchReset}
+            aria-label="Clear the query"
+          >
+            <svg
+              height="20"
+              width="20"
+              viewBox="0 0 20 20"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path
+                stroke="none"
+                fill="currentColor"
+                d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
+              ></path>
+            </svg>
+          </button>
+        )}
+      </form>
+      <div className={clsx('row', 'padding-top--md')}>
+        {filteredResults.map((plugin) => (
+          <PluginCard key={plugin.name} {...plugin} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/PluginCardsList/styles.module.css
+++ b/src/components/PluginCardsList/styles.module.css
@@ -1,0 +1,52 @@
+.pluginTextSearch:focus-within {
+    box-shadow: inset 0 0 0 2px var(--docsearch-primary-color);
+    outline: none;
+}
+
+.pluginTextSearch:hover {
+    box-shadow: inset 0 0 0 2px var(--docsearch-primary-color);
+    outline: none;
+}
+
+.pluginTextSearch:active {
+    box-shadow: inset 0 0 0 2px var(--ifm-color-secondary);
+    outline: none;
+}
+
+.pluginTextSearch {
+    box-shadow: inset 0 0 0 1px var(--ifm-color-secondary-darkest);
+    border: 0px;
+}
+
+.pluginForm {
+    align-items: center;
+    background: var(--ifm-card-background-color);
+    border-radius: 4px;
+    box-shadow: inset 0 0 0 1px var(--ifm-color-secondary-darkest);
+    display: flex;
+    height: var(--docsearch-searchbox-height);
+    margin: 0;
+    padding: 0 var(--docsearch-spacing);
+    position: relative;
+    width: 100%
+}
+
+.searchIcon {
+    color: var(--ifm-color-emphasis-500);
+}
+
+.searchReset {
+    animation: fade-in .1s ease-in forwards;
+    appearance: none;
+    background: none;
+    border: 0;
+    color: var(--ifm-color-emphasis-500);
+    cursor: pointer;
+    padding: 2px;
+    right: 0;
+    stroke-width: var(--docsearch-icon-stroke-width)
+}
+
+.searchReset:hover {
+    color: var(--ifm-color-secondary-contrast-foreground);
+}

--- a/src/data/plugins.tsx
+++ b/src/data/plugins.tsx
@@ -1,0 +1,225 @@
+const TAGS = {
+  AGENT: 'Agent',
+  CUMULOCITY: 'Cumulocity IoT',
+  OPERATION: 'Operation',
+  MICROCONTROLLER: 'Microcontroller',
+  YOCTO: 'Yocto',
+  RUGPI: 'Rugpi',
+  IMAGE: 'Image',
+  SM_PLUGIN: 'Software Management Plugins',
+  CONTAINER: 'Container',
+  UI: 'UI',
+  TOOL: 'Tool',
+  PROTOCOLS: 'Protocols',
+  NODE_RED: 'NodeRED',
+  BENCHMARK: 'Benchmark',
+  INIT_SYSTEM: 'Init Systems',
+  RASPBERRY_PI: 'Raspberry Pi',
+  TELEMETRY: 'Telemetry',
+  CONFIG: 'Configuration',
+  SERVICE: 'Service',
+  BOOTSTRAP: 'Bootstrap',
+};
+
+export interface IPlugin {
+  name: string;
+  sourceUrl?: string;
+  packageUrl?: string;
+  description: string;
+  tags: string[];
+}
+
+const PluginsList: IPlugin[] = [
+  // Agents
+  {
+    name: 'rpi-pico-client',
+    sourceUrl: 'https://github.com/thin-edge/rpi-pico-client',
+    description:
+      'Micropython agent (for microcontrollers) to connect to local thin-edge.io to manage devices like Raspberry Pi Pico W',
+    tags: [TAGS.AGENT, TAGS.MICROCONTROLLER, TAGS.RASPBERRY_PI],
+  },
+  {
+    name: 'python-tedge-agent',
+    sourceUrl: 'https://github.com/thin-edge/python-tedge-agent',
+    description:
+      'Python3 agent to connect to local thin-edge.io to manage devices',
+    tags: [TAGS.AGENT],
+  },
+
+  // Configuration
+  {
+    name: 'tedge-config2mqtt-watcher',
+    sourceUrl: 'https://github.com/thin-edge/tedge-config2mqtt-watcher',
+    description:
+      'Services which watches the tedge.toml file and publishes message on the local MQTT broker',
+    tags: [TAGS.CONFIG, TAGS.SERVICE],
+  },
+
+  // Init Systems
+  {
+    name: 'tedge-sysvinit',
+    sourceUrl: 'https://github.com/thin-edge/tedge-services',
+    description: 'thin-edge.io sysvinit service definitions',
+    tags: [TAGS.INIT_SYSTEM],
+  },
+  {
+    name: 'tedge-systemd',
+    sourceUrl: 'https://github.com/thin-edge/tedge-services',
+    description:
+      'thin-edge.io systemd service definitions. Note: These definitions are provided to make it easier to add into Yocto builds.',
+    tags: [TAGS.INIT_SYSTEM],
+  },
+  {
+    name: 'tedge-openrc',
+    sourceUrl: 'https://github.com/thin-edge/tedge-services',
+    description: 'thin-edge.io OpenRC service definitions',
+    tags: [TAGS.INIT_SYSTEM],
+  },
+  {
+    name: 'tedge-runit',
+    sourceUrl: 'https://github.com/thin-edge/tedge-services',
+    description: 'thin-edge.io runit service definitions',
+    tags: [TAGS.INIT_SYSTEM],
+  },
+  {
+    name: 'tedge-s6overlay',
+    sourceUrl: 'https://github.com/thin-edge/tedge-services',
+    description: 'thin-edge.io s6overlay service definitions',
+    tags: [TAGS.INIT_SYSTEM],
+  },
+  {
+    name: 'tedge-supervisord',
+    sourceUrl: 'https://github.com/thin-edge/tedge-services',
+    description: 'thin-edge.io supervisord service definitions',
+    tags: [TAGS.INIT_SYSTEM],
+  },
+
+  // Operations
+  {
+    name: 'c8y-command-plugin',
+    sourceUrl: 'https://github.com/thin-edge/c8y-command-plugin',
+    description: 'Execute shell commands via MQTT',
+    tags: [TAGS.OPERATION, TAGS.CUMULOCITY],
+  },
+  {
+    name: 'c8y-textconfig-plugin',
+    sourceUrl: 'https://github.com/thin-edge/c8y-textconfig-plugin',
+    description: 'Send text-based configuration via MQTT',
+    tags: [TAGS.OPERATION, TAGS.CUMULOCITY],
+  },
+
+  // Images
+  {
+    name: 'tedge-rugpi-image',
+    sourceUrl: 'https://github.com/thin-edge/tedge-rugpi-image',
+    packageUrl: 'https://github.com/thin-edge/tedge-rugpi-image',
+    description:
+      'Build Raspberry Pi images with in-built support for OS updates using thin-edge.io and [Rugpi](https://github.com/silitics/rugpi)',
+    tags: [TAGS.IMAGE, TAGS.RASPBERRY_PI],
+  },
+  {
+    name: 'meta-tedge-project',
+    sourceUrl: 'https://github.com/thin-edge/meta-tedge-project',
+    packageUrl: 'https://github.com/thin-edge/meta-tedge-project',
+    description:
+      'Yocto Project to easily build multiple thin-edge.io images using different firmware update layers',
+    tags: [TAGS.IMAGE, TAGS.YOCTO],
+  },
+  {
+    name: 'meta-tedge',
+    sourceUrl: 'https://github.com/thin-edge/meta-tedge',
+    packageUrl: 'https://github.com/thin-edge/meta-tedge',
+    description: 'Yocto Layer to build and install thin-edge.io from source',
+    tags: [TAGS.IMAGE, TAGS.YOCTO],
+  },
+  {
+    name: 'meta-tedge-bin',
+    sourceUrl: 'https://github.com/thin-edge/meta-tedge-bin',
+    packageUrl: 'https://github.com/thin-edge/meta-tedge-bin',
+    description:
+      'Yocto Layer to install thin-edge.io using the officially built binaries. This layer reduces the build time considering as it avoids having to build the Rust compiler and tooling.',
+    tags: [TAGS.IMAGE, TAGS.YOCTO],
+  },
+
+  // Protocols
+  {
+    name: 'modbus',
+    sourceUrl: 'https://github.com/thin-edge/modbus-plugin',
+    description:
+      'Modbus gateway to connect to modbus devices and publish to the cloud via thin-edge.io.',
+    tags: [TAGS.PROTOCOLS],
+  },
+  {
+    name: 'OPC UA',
+    sourceUrl:
+      'https://github.com/thin-edge/thin-edge.io_examples/tree/main/opcua-solution',
+    description:
+      'OPC UA Gateway example which uses the Cumulocity IoT [opcua-device-gateway](https://github.com/thin-edge/opcua-device-gateway-container) to connect to OPC UA Servers and thin-edge.io',
+    tags: [TAGS.PROTOCOLS],
+  },
+
+  // Software management plugins
+  {
+    name: 'tedge-apk-plugin',
+    description: 'Manage Alpine Linux (apk) Packages',
+    tags: [TAGS.SM_PLUGIN],
+  },
+  {
+    name: 'tedge-rpm-plugin',
+    description: 'Manage rpm packages via dnf/microdnf/zypper',
+    tags: [TAGS.SM_PLUGIN],
+  },
+  {
+    name: 'tedge-snap-plugin',
+    description: 'Manage snap packages on Ubuntu',
+    tags: [TAGS.SM_PLUGIN],
+  },
+  {
+    name: 'tedge-container-plugin',
+    description: 'Manage container or container groups (e.g. docker compose)',
+    tags: [TAGS.SM_PLUGIN, TAGS.CONTAINER],
+  },
+  {
+    name: 'tedge-nodered-plugin',
+    description: 'Manage NodeRED flows',
+    tags: [TAGS.SM_PLUGIN, TAGS.NODE_RED],
+  },
+
+  // Telemetry
+  {
+    name: 'tedge-inventory-plugin',
+    description:
+      'Collect device information periodically via simple script based interface',
+    tags: [TAGS.TELEMETRY],
+  },
+
+  // Tools
+  {
+    name: 'c8y-tedge',
+    description:
+      '[go-c8y-cli](https://goc8ycli.netlify.app/) extension to provide common utilities to help with bootstrapping thin-edge.io devices to Cumulocity IoT',
+    sourceUrl: 'https://github.com/thin-edge/c8y-tedge',
+    packageUrl: 'https://github.com/thin-edge/c8y-tedge',
+    tags: [TAGS.TOOL, TAGS.BOOTSTRAP],
+  },
+  {
+    name: 'tedge-benchmark',
+    description:
+      'Python based MQTT benchmarking package to test the throughput of the MQTT message on a target device',
+    sourceUrl: 'https://github.com/thin-edge/tedge-benchmark',
+    tags: [TAGS.TOOL, TAGS.BENCHMARK],
+  },
+
+  // UI
+  {
+    name: 'tedge-management-ui',
+    description: 'Local UI to view and manage thin-edge.io',
+    sourceUrl: 'https://github.com/thin-edge/tedge-management-ui',
+    tags: [TAGS.UI],
+  },
+];
+
+// Sort plugins
+export const Plugins = PluginsList.sort((a, b) =>
+  a.name.toLocaleLowerCase() < b.name.toLocaleLowerCase() ? -1 : 1,
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -277,7 +277,7 @@
   dependencies:
     "@babel/types" "^7.23.0"
 
-"@babel/helper-module-imports@^7.22.15":
+"@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.22.15":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz#16146307acdc40cc00c3b2c647713076464bdbf0"
   integrity sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==
@@ -1144,7 +1144,7 @@
     core-js-pure "^3.30.2"
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.22.6", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.22.6", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.23.8"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.8.tgz#8ee6fe1ac47add7122902f257b8ddf55c898f650"
   integrity sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==
@@ -1667,6 +1667,114 @@
     tslib "^2.6.0"
     url-loader "^4.1.1"
     webpack "^5.88.1"
+
+"@emotion/babel-plugin@^11.11.0":
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz#c2d872b6a7767a9d176d007f5b31f7d504bb5d6c"
+  integrity sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/runtime" "^7.18.3"
+    "@emotion/hash" "^0.9.1"
+    "@emotion/memoize" "^0.8.1"
+    "@emotion/serialize" "^1.1.2"
+    babel-plugin-macros "^3.1.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "4.2.0"
+
+"@emotion/cache@^11.11.0", "@emotion/cache@^11.4.0":
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.11.0.tgz#809b33ee6b1cb1a625fef7a45bc568ccd9b8f3ff"
+  integrity sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==
+  dependencies:
+    "@emotion/memoize" "^0.8.1"
+    "@emotion/sheet" "^1.2.2"
+    "@emotion/utils" "^1.2.1"
+    "@emotion/weak-memoize" "^0.3.1"
+    stylis "4.2.0"
+
+"@emotion/hash@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.1.tgz#4ffb0055f7ef676ebc3a5a91fb621393294e2f43"
+  integrity sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==
+
+"@emotion/memoize@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.1.tgz#c1ddb040429c6d21d38cc945fe75c818cfb68e17"
+  integrity sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==
+
+"@emotion/react@^11.8.1":
+  version "11.11.3"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.11.3.tgz#96b855dc40a2a55f52a72f518a41db4f69c31a25"
+  integrity sha512-Cnn0kuq4DoONOMcnoVsTOR8E+AdnKFf//6kUWc4LCdnxj31pZWn7rIULd6Y7/Js1PiPHzn7SKCM9vB/jBni8eA==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.11.0"
+    "@emotion/cache" "^11.11.0"
+    "@emotion/serialize" "^1.1.3"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.1"
+    "@emotion/utils" "^1.2.1"
+    "@emotion/weak-memoize" "^0.3.1"
+    hoist-non-react-statics "^3.3.1"
+
+"@emotion/serialize@^1.1.2", "@emotion/serialize@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.1.3.tgz#84b77bfcfe3b7bb47d326602f640ccfcacd5ffb0"
+  integrity sha512-iD4D6QVZFDhcbH0RAG1uVu1CwVLMWUkCvAqqlewO/rxf8+87yIBAlt4+AxMiiKPLs5hFc0owNk/sLLAOROw3cA==
+  dependencies:
+    "@emotion/hash" "^0.9.1"
+    "@emotion/memoize" "^0.8.1"
+    "@emotion/unitless" "^0.8.1"
+    "@emotion/utils" "^1.2.1"
+    csstype "^3.0.2"
+
+"@emotion/sheet@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.2.tgz#d58e788ee27267a14342303e1abb3d508b6d0fec"
+  integrity sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==
+
+"@emotion/unitless@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.1.tgz#182b5a4704ef8ad91bde93f7a860a88fd92c79a3"
+  integrity sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==
+
+"@emotion/use-insertion-effect-with-fallbacks@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz#08de79f54eb3406f9daaf77c76e35313da963963"
+  integrity sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==
+
+"@emotion/utils@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.2.1.tgz#bbab58465738d31ae4cb3dbb6fc00a5991f755e4"
+  integrity sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==
+
+"@emotion/weak-memoize@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz#d0fce5d07b0620caa282b5131c297bb60f9d87e6"
+  integrity sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==
+
+"@floating-ui/core@^1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.3.tgz#b6aa0827708d70971c8679a16cf680a515b8a52a"
+  integrity sha512-O0WKDOo0yhJuugCx6trZQj5jVJ9yR0ystG2JaNAemYUWce+pmM6WUEFIibnWyEJKdrDxhm75NoSRME35FNaM/Q==
+  dependencies:
+    "@floating-ui/utils" "^0.2.0"
+
+"@floating-ui/dom@^1.0.1":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.4.tgz#28df1e1cb373884224a463235c218dcbd81a16bb"
+  integrity sha512-jByEsHIY+eEdCjnTVu+E3ephzTOzkQ8hgUfGwos+bg7NlH33Zc5uO+QHz1mrQUOgIKKDD1RtS201P9NvAfq3XQ==
+  dependencies:
+    "@floating-ui/core" "^1.5.3"
+    "@floating-ui/utils" "^0.2.0"
+
+"@floating-ui/utils@^0.2.0":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.1.tgz#16308cea045f0fc777b6ff20a9f25474dd8293d2"
+  integrity sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==
 
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"
@@ -2271,6 +2379,13 @@
     "@types/history" "^4.7.11"
     "@types/react" "*"
 
+"@types/react-transition-group@^4.4.0":
+  version "4.4.10"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.10.tgz#6ee71127bdab1f18f11ad8fb3322c6da27c327ac"
+  integrity sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^18.2.48":
   version "18.2.48"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.48.tgz#11df5664642d0bd879c1f58bc1d37205b064e8f1"
@@ -2717,6 +2832,15 @@ babel-plugin-dynamic-import-node@^2.3.3:
   integrity sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==
   dependencies:
     object.assign "^4.1.0"
+
+babel-plugin-macros@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
+  integrity sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    cosmiconfig "^7.0.0"
+    resolve "^1.19.0"
 
 babel-plugin-polyfill-corejs2@^0.4.7:
   version "0.4.7"
@@ -3228,6 +3352,11 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
 
+convert-source-map@^1.5.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
+  integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
+
 convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
@@ -3307,7 +3436,7 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-cosmiconfig@^7.0.1:
+cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
   integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
@@ -3987,6 +4116,14 @@ dom-converter@^0.2.0:
   dependencies:
     utila "~0.4"
 
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
+
 dom-serializer@^1.0.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.4.1.tgz#de5d41b1aea290215dc45a6dae8adcf1d32e2d30"
@@ -4455,6 +4592,11 @@ find-cache-dir@^4.0.0:
     common-path-prefix "^3.0.0"
     pkg-dir "^7.0.0"
 
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
+
 find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -4914,7 +5056,7 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
-hoist-non-react-statics@^3.1.0:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -4971,6 +5113,11 @@ html-tags@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.3.1.tgz#a04026a18c882e4bba8a01a3d39cfe465d40b5ce"
   integrity sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==
+
+html-url-attributes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-url-attributes/-/html-url-attributes-3.0.0.tgz#fc4abf0c3fb437e2329c678b80abb3c62cff6f08"
+  integrity sha512-/sXbVCWayk6GDVg3ctOX6nxaVj7So40FcFAnWlWGNAB1LpYKcV5Cd10APjPjW80O7zYW2MsjBV4zZ7IZO5fVow==
 
 html-void-elements@^3.0.0:
   version "3.0.0"
@@ -5950,7 +6097,7 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
-medium-zoom@^1.0.8:
+medium-zoom@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/medium-zoom/-/medium-zoom-1.1.0.tgz#6efb6bbda861a02064ee71a2617a8dc4381ecc71"
   integrity sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==
@@ -5961,6 +6108,11 @@ memfs@^3.1.2, memfs@^3.4.3:
   integrity sha512-EGowvkkgbMcIChjMTMkESFDbZeSh8xZ7kNSF0hAiAN4Jh6jgHCRS0Ga/+C8y6Au+oqpezRHCfPsmJ2+DwAgiwQ==
   dependencies:
     fs-monkey "^1.0.4"
+
+memoize-one@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
+  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -7101,7 +7253,7 @@ plugin-image-zoom@flexanalytics/plugin-image-zoom:
   version "1.1.0"
   resolved "https://codeload.github.com/flexanalytics/plugin-image-zoom/tar.gz/8e1b866c79ed6d42cefc4c52f851f1dfd1d0c7de"
   dependencies:
-    medium-zoom "^1.0.8"
+    medium-zoom "^1.0.4"
 
 postcss-calc@^8.2.3:
   version "8.2.4"
@@ -7432,7 +7584,7 @@ prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -7622,6 +7774,22 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   dependencies:
     "@babel/runtime" "^7.10.3"
 
+react-markdown@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-9.0.1.tgz#c05ddbff67fd3b3f839f8c648e6fb35d022397d1"
+  integrity sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    devlop "^1.0.0"
+    hast-util-to-jsx-runtime "^2.0.0"
+    html-url-attributes "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    remark-parse "^11.0.0"
+    remark-rehype "^11.0.0"
+    unified "^11.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+
 react-router-config@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-router-config/-/react-router-config-5.1.1.tgz#0f4263d1a80c6b2dc7b9c1902c9526478194a988"
@@ -7656,6 +7824,31 @@ react-router@5.3.4, react-router@^5.3.4:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-select@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.8.0.tgz#bd5c467a4df223f079dd720be9498076a3f085b5"
+  integrity sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/react" "^11.8.1"
+    "@floating-ui/dom" "^1.0.1"
+    "@types/react-transition-group" "^4.4.0"
+    memoize-one "^6.0.0"
+    prop-types "^15.6.0"
+    react-transition-group "^4.3.0"
+    use-isomorphic-layout-effect "^1.1.2"
+
+react-transition-group@^4.3.0:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@^18.2.0:
   version "18.2.0"
@@ -7905,7 +8098,7 @@ resolve-pathname@^3.0.0:
   resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
   integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
-resolve@^1.1.6, resolve@^1.14.2:
+resolve@^1.1.6, resolve@^1.14.2, resolve@^1.19.0:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -8276,6 +8469,11 @@ source-map-support@~0.5.20:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
+source-map@^0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
+
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
@@ -8448,6 +8646,11 @@ stylehacks@^5.1.1:
   dependencies:
     browserslist "^4.21.4"
     postcss-selector-parser "^6.0.4"
+
+stylis@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.2.0.tgz#79daee0208964c8fe695a42fcffcac633a211a51"
+  integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
 
 stylis@^4.1.3:
   version "4.3.1"
@@ -8787,6 +8990,11 @@ url-loader@^4.1.1:
     loader-utils "^2.0.0"
     mime-types "^2.1.27"
     schema-utils "^3.0.0"
+
+use-isomorphic-layout-effect@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
+  integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Add new Reactjs component to display a list of community plugins generated from a list which is mainted in the file: /src/components/PluginCardsList/index.tsx

This PR does not actually include usage of the component, this will be done in a follow PR (as this change has to be done via a markdown page).

## Examples

### Dark mode

<img width="829" alt="image" src="https://github.com/thin-edge/tedge-docs/assets/3029781/75c8df03-6fa6-4b19-a70f-5f508c77a51a">

### Light mode

<img width="817" alt="image" src="https://github.com/thin-edge/tedge-docs/assets/3029781/fa50aaa1-3968-434d-a011-2a727415c723">

### Filter by keyword (tag)

<img width="828" alt="image" src="https://github.com/thin-edge/tedge-docs/assets/3029781/28b79d85-427d-4574-9a5a-19f979f7a423">

### Filter by text (name and/or description)

<img width="822" alt="image" src="https://github.com/thin-edge/tedge-docs/assets/3029781/b36ffd5d-05d4-47b7-aff0-40cd5d8359d3">

