### PR TITLE
fix: support searching when using dev server by using same baseUrl as prod

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,7 +12,7 @@ import tabBlocks from 'docusaurus-remark-plugin-tab-blocks';
 
 const docsDir = process.env.DOCS_DIR || 'docs';
 const domain = process.env.DOMAIN || 'https://thin-edge.github.io';
-const baseUrl = process.env.BASE_URL || '/';
+const baseUrl = process.env.BASE_URL || '/thin-edge.io/';
 const includeCurrentVersion = process.env.INCLUDE_CURRENT_VERSION || 'true';
 
 /** @type {import('@docusaurus/types').Config} */


### PR DESCRIPTION
Use the same baseUrl as used in production so that the search links work when using a local dev server to browse the docs.

Resolves https://github.com/thin-edge/tedge-docs/issues/48

**Note**

The search function is still using an index generated from the production logs, so it will not included results for any new pages, so don't be surprised if some 404 links are still occur.