### PR TITLE
feat: replace thin-edge.io placeholder syntax to avoid false negatives when checking for unused global variables

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,7 +24,7 @@ const config = {
     mermaid: true,
     // Use preprocessor to replace global variables
     preprocessor: ({ filePath, fileContent }) => {
-      return fileContent.replaceAll('{{te}}', '**thin-edge.io**');
+      return fileContent.replaceAll('%%te%%', '**thin-edge.io**');
     },
   },
   themes: ['@docusaurus/theme-mermaid'],


### PR DESCRIPTION
Replace the thin-edge.io placeholder text from `{{te}}` to `%%te%%` to avoid a problem with the mdx file checker, https://github.com/slorber/docusaurus-mdx-checker.

The `{{}}` syntax would cause an error when validating the documentation in the thin-edge.io PR checks due to the variable not being defined at the time of the check. The new syntax does not trigger such a false negative.