### PR TITLE
feat: support opting out of image zoom on specific images

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -272,6 +272,11 @@ const config = {
         contextualSearch: true,
         searchParameters: {},
       },
+      imageZoom: {
+        // Allow disabling image zoom on specific images
+        // by surrounding them in `_![image](image.png)_` or <em></em>
+        selector: '.markdown :not(em) > img',
+      },
     }),
 };
 


### PR DESCRIPTION
Docs can now opt out of the image zoom (e.g. click to zoom) function.

Below shows examples how to opt out:

**Markdown**

````
_![image](image.png)_
````

**MDX**

```
<em><img width="80" height="80" src="https://assets.cloudsmith.media/package/images/backends/deb/large.30f93502b7b5.png" alt="Debian logo" /></em>
```
