### PR TITLE
feat: create snapshot workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+    branches: [main]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: publish github pages
+        run: |
+          gh workflow run gh-pages.yml -R thin-edge/thin-edge.io
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_PAT }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,40 @@
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        type: string
+        required: true
+      branch:
+        description: |
+          Branch to take the snapshot from. Use to update docs for the current release by
+          taking the state from a branch rather than a tag
+        type: string
+        required: false
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{inputs.version}}
+      PR_BRANCH: release-${{inputs.version}}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: extractions/setup-just@v1
+      - run: |
+          git config --global user.email "info@thin-edge.io"
+          git config --global user.name "Versioneer"
+          git checkout -b "$PR_BRANCH"
+          if [ -n "${{inputs.branch}}" ]; then
+            just checkout-version "$VERSION"
+            git commit -am "Create snapshot for version $VERSION"
+          else
+            just checkout-version "$VERSION" "${{inputs.branch}}"
+            git commit -am "Backporting snapshot for version $VERSION on branch"
+          fi
+          git push origin
+      - name: create pull request
+        run: gh pr create -B main -H "$PR_BRANCH" --title "create snapshot for version $VERSION" --body "Release $VERSION"
+        env:
+            GITHUB_TOKEN: ${{ secrets.ACTIONS_PAT }}

--- a/justfile
+++ b/justfile
@@ -45,9 +45,6 @@ checkout-version version="" branch="":
         SOURCE_REPO_INFO="$TAG"
     fi
 
-    echo "Creating list of versions to be included (only 1 is supported atm)"
-    printf '["%s"]' "$TAG"  > versions.json
-
     echo "Copying docs from $TAG"
     mkdir -p versioned_docs
     rm -rf "./versioned_docs/version-$TAG"
@@ -56,6 +53,10 @@ checkout-version version="" branch="":
 
     # Store marker info about the source repo so it is easier to trace
     printf '%s' "$SOURCE_REPO_INFO" > "./versioned_docs/version-$TAG/.version"
+
+    # Create versions
+    echo "Creating list of versions to be included (only 1 is supported atm)"
+    ls -1r versioned_docs | cut -d- -f2- | jq -s -R 'split("\n") | .[:-1]' -c  > versions.json
 
     echo "Creating versioned sidebars"
     mkdir -p versioned_sidebars


### PR DESCRIPTION
Add a github workflow to create thin-edge.io version snapshots. The workflow can be manually triggered, or via the thin-edge.io project (https://github.com/thin-edge/thin-edge.io/pull/2702).

* The version list is automatically generated via jq (based on the version-* folders)
* Trigger thin-edge github pages publish job when merging into main