### PR TITLE
ci: reuse checkout credentials to push branch

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -20,8 +20,6 @@ jobs:
       PR_BRANCH: release-${{inputs.version}}
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
       - uses: extractions/setup-just@v1
       - name: Create snapshot
         run: |


### PR DESCRIPTION
Fix bug where the git push didn't have credentials to push the branch