### PR TITLE
fix(ci): snapshot from branch reference

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -34,7 +34,7 @@ jobs:
             just checkout-version "$VERSION"
             git commit -am "Create snapshot for version $VERSION"
           fi
-          git push --set-upstream origin release-1.0.0
+          git push --set-upstream origin "$PR_BRANCH"
       - name: create pull request
         run: gh pr create -B main -H "$PR_BRANCH" --title "create snapshot for version $VERSION" --body "Release $VERSION"
         env:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -18,6 +18,7 @@ jobs:
     env:
       VERSION: ${{inputs.version}}
       PR_BRANCH: release-${{inputs.version}}
+      SOURCE_BRANCH: ${{inputs.branch || ''}}
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v1
@@ -26,12 +27,12 @@ jobs:
           git config --global user.email "info@thin-edge.io"
           git config --global user.name "Versioneer"
           git checkout -b "$PR_BRANCH"
-          if [ -n "${{inputs.branch}}" ]; then
+          if [ -n "$SOURCE_BRANCH" ]; then
+            just checkout-version "$VERSION" "$SOURCE_BRANCH"
+            git commit -am "Backporting snapshot for version $VERSION on branch"  
+          else
             just checkout-version "$VERSION"
             git commit -am "Create snapshot for version $VERSION"
-          else
-            just checkout-version "$VERSION" "${{inputs.branch}}"
-            git commit -am "Backporting snapshot for version $VERSION on branch"
           fi
           git push --set-upstream origin release-1.0.0
       - name: create pull request


### PR DESCRIPTION
Fix an issue where creating a doc snapshot from a branch would still try to reference a tag (due to inverted logic in the tag/branch check)