### PR TITLE
ci: update search index when triggering gh_pages deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,6 @@ jobs:
     steps:
       - name: publish github pages
         run: |
-          gh workflow run gh-pages.yml -R thin-edge/thin-edge.io
+          gh workflow run gh-pages.yml -R thin-edge/thin-edge.io -f update_search_index=true
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_PAT }}


### PR DESCRIPTION
Set option to update the Algolia search index when deploying the gh pages (introduced in [thin-edge.io #2927](https://github.com/thin-edge/thin-edge.io/pull/2927).

It should only be mergdd after the above PR is merged.