### PR TITLE
feat: add user context components to allow users to customize the instructions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@docusaurus/preset-classic": "^3.1.0",
     "@docusaurus/theme-mermaid": "^3.1.0",
     "@mdx-js/react": "^3.0.0",
+    "@uidotdev/usehooks": "^2.4.1",
     "clsx": "^1.2.1",
     "default-passive-events": "^2.0.0",
     "docusaurus-remark-plugin-tab-blocks": "^3.0.0",

--- a/src/components/UserContext/index.js
+++ b/src/components/UserContext/index.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import CodeBlock from '@theme/CodeBlock';
+import { useLocalStorage } from "@uidotdev/usehooks";
+
+export default function UserContext(props={}) {
+  const {children={}, language="sh"} = props;
+  // Common
+  const [deviceId] = useLocalStorage('DEVICE_ID', props.deviceId || 'tedge001');
+
+  // Cumulocity IoT
+  const [c8yUrl] = useLocalStorage('C8Y_URL', props.c8yUrl || 'example.eu-latest.com');
+  const [c8yUser] = useLocalStorage('C8Y_USER', props.c8yUser || 'jimmy@thin-edge.com');
+
+  // AWS
+  const [awsUrl] = useLocalStorage('AWS_URL', props.awsUrl || 'b1a1agbpo20syc.iot.us-east-1.amazonaws.com');
+  const [awsRegion] = useLocalStorage('AWS_REGION', props.awsRegion || 'us-east-1');
+  const [awsAccountId] = useLocalStorage('AWS_ACCOUNT_ID', props.awsAccountId || '123456789012');
+
+  // Azure
+  const [azureUrl] = useLocalStorage('AZURE_URL', props.azureUrl || 'your-iot-hub-name.azure-devices.net');
+
+  const code = `${children.props.children.props.children || children.props.children}`
+    .replace(/\$DEVICE_ID/g, deviceId)
+    .replace(/\$C8Y_URL/g, c8yUrl)
+    .replace(/\$C8Y_USER/g, c8yUser)
+    .replace(/\$AWS_URL/g, awsUrl)
+    .replace(/\$AWS_REGION/g, awsRegion)
+    .replace(/\$AWS_ACCOUNT_ID/g, awsAccountId)
+    .replace(/\$AZURE_URL/g, azureUrl)
+  ;
+  return (
+    <div>
+      <CodeBlock language={language} >
+          {code}
+      </CodeBlock>
+    </div>
+  );
+}

--- a/src/components/UserContextForm/index.js
+++ b/src/components/UserContextForm/index.js
@@ -1,0 +1,126 @@
+import React, { useEffect } from 'react';
+import { useLocalStorage } from "@uidotdev/usehooks";
+
+function generateName(prefix='', len=10) {
+  const genRanHex = size => [...Array(size)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
+  return prefix + genRanHex(len);
+}
+
+export default function UserContextForm(props={}) {
+  const {settings = ''} = props;
+  const showKeys = `${settings}`.split(',');
+
+  // Common
+  const [deviceId, setDeviceId] = useLocalStorage('DEVICE_ID', props.deviceId || generateName('tedge_'));
+  useEffect(() => setDeviceId(deviceId), [deviceId]);
+
+  // Cumulocity IoT
+  const [c8yUrl, setC8yUrl] = useLocalStorage('C8Y_URL', props.c8yUrl || 'example.eu-latest.com');
+  useEffect(() => updateUrl(c8yUrl), [c8yUrl]);
+  const updateUrl = (url) => {
+    setC8yUrl(`${url}`.replace(/^https?:\/\//i, ''))
+  };
+
+  const [c8yUser, setC8yUser] = useLocalStorage('C8Y_USER', props.c8yUser || 'jimmy@thin-edge.com');
+  useEffect(() => setC8yUser(c8yUser), [c8yUser]);
+
+  // AWS
+  const [awsUrl, setAwsUrl] = useLocalStorage('AWS_URL', props.awsUrl || 'b1a1agbpo20syc.iot.us-east-1.amazonaws.com');
+  useEffect(() => setAwsUrl(awsUrl), [awsUrl]);
+
+  const [awsRegion, setAwsRegion] = useLocalStorage('AWS_REGION', props.awsRegion || 'us-east-1');
+  useEffect(() => setAwsRegion(awsRegion), [awsRegion]);
+
+  const [awsAccountId, setAwsAccountId] = useLocalStorage('AWS_ACCOUNT_ID', props.awsAccountId || '123456789012');
+  useEffect(() => setAwsAccountId(awsAccountId), [awsAccountId]);
+
+  // Azure
+  const [azureUrl, setAzureUrl] = useLocalStorage('AZURE_URL', props.azUrl || 'your-iot-hub-name.azure-devices.net');
+  useEffect(() => setAzureUrl(azureUrl), [azureUrl]);
+
+  const showStyle = (key) => {
+    if (!showKeys.includes(key)) {
+      return {
+        'display': 'none',
+      };
+    }
+  };
+
+  // Control if context is expanded or not
+  const [showContext, setShowContext] = useLocalStorage('SHOW_CONTEXT', true);
+  useEffect(() => setShowContext(showContext), [showContext]);
+
+  return (
+    <div>
+    <button onClick={e => setShowContext(!showContext)} style={{'width': '100%'}}>Show/hide user context</button>
+    <div className="card" style={{'display': showContext ? 'inherit': 'none'}}>
+        <div className="card__body">
+          <div className='container'>
+            <div className="row margin--xs" style={showStyle('DEVICE_ID')}>
+              <div className="col col--4">
+                <label htmlFor="device-id">Device ID</label>
+              </div>
+              <div className="col col--6">
+                <input id="device-id" inputMode="text" value={deviceId} onChange={(e) => setDeviceId(e.target.value)}></input>
+              </div>
+            </div>
+
+            <div className="row margin--xs" style={showStyle('C8Y_URL')}>
+              <div className="col col--4">
+                <label htmlFor="c8y-url">Cumulocity IoT URL</label>
+              </div>
+              <div className="col col--6">
+                <input id="c8y-url" inputMode="text" value={c8yUrl} onChange={(e) => updateUrl(e.target.value)}></input>
+              </div>
+            </div>
+
+            <div className="row margin--xs" style={showStyle('C8Y_USER')}>
+              <div className="col col--4">
+                <label htmlFor="c8y-user">Cumulocity IoT User</label>
+              </div>
+              <div className="col col--6">
+              <input id="c8y-user" inputMode="text" value={c8yUser} onChange={(e) => setC8yUser(e.target.value)}></input>
+              </div>
+            </div>
+
+            <div className="row margin--xs" style={showStyle('AWS_URL')}>
+              <div className="col col--4">
+                <label htmlFor="aws-url">AWS URL</label>
+              </div>
+              <div className="col col--6">
+              <input id="aws-url" inputMode="text" value={awsUrl} onChange={(e) => setAwsUrl(e.target.value)}></input>
+              </div>
+            </div>
+
+            <div className="row margin--xs" style={showStyle('AWS_REGION')}>
+              <div className="col col--4">
+                <label htmlFor="aws-region">AWS Region</label>
+              </div>
+              <div className="col col--6">
+              <input id="aws-region" inputMode="text" value={awsRegion} onChange={(e) => setAwsRegion(e.target.value)}></input>
+              </div>
+            </div>
+
+            <div className="row margin--xs" style={showStyle('AWS_ACCOUNT_ID')}>
+              <div className="col col--4">
+                <label htmlFor="aws-account-id">AWS Account ID</label>
+              </div>
+              <div className="col col--6">
+              <input id="aws-account-id" inputMode="text" value={awsAccountId} onChange={(e) => setAwsAccountId(e.target.value)}></input>
+              </div>
+            </div>
+
+            <div className="row margin--xs" style={showStyle('AZURE_URL')}>
+              <div className="col col--4">
+                <label htmlFor="aws-account-id">Azure URL</label>
+              </div>
+              <div className="col col--6">
+              <input id="aws-account-id" inputMode="text" value={azureUrl} onChange={(e) => setAzureUrl(e.target.value)}></input>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -76,3 +76,45 @@ html[data-theme='dark'] .header-github-link:before {
 .logo {
   margin: 20px;
 }
+
+input {
+  margin-bottom: 1rem;
+  width: 100%;
+  font-size: 1rem;
+  padding: 0.4rem;
+}
+
+input[type="text"] {
+  height: 40px;
+  padding: 0.5rem 1rem;
+  border: 1px solid #999;
+}
+
+input[type="submit"] {
+  background-color: #000000;
+  border: none;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  height: 40px;
+  cursor: pointer;
+}
+
+input:focus {
+  outline: none;
+  border-color: #000000;
+}
+
+input[type="checkbox"] {
+  display: inline-block;
+  width: auto;
+}
+
+button {
+  border-radius: 4px;
+  border-width: 1px;
+  padding: 6px 18px;
+  /* border-color: var(--ifm-color-primary-light); */
+  /* background-color: var(--ifm-color-primary-contrast-background); */
+  background-color: var(--ifm-color-primary-contrast-background);
+  cursor: pointer;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1504,7 +1504,7 @@
     "@docusaurus/theme-search-algolia" "3.1.0"
     "@docusaurus/types" "3.1.0"
 
-"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -2476,6 +2476,11 @@
   integrity sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@uidotdev/usehooks@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@uidotdev/usehooks/-/usehooks-2.4.1.tgz#4b733eaeae09a7be143c6c9ca158b56cc1ea75bf"
+  integrity sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==
 
 "@ungap/structured-clone@^1.0.0":
   version "1.2.0"
@@ -7773,6 +7778,14 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   integrity sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==
   dependencies:
     "@babel/runtime" "^7.10.3"
+
+"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
+  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
+  dependencies:
+    "@types/react" "*"
+    prop-types "^15.6.2"
 
 react-markdown@^9.0.1:
   version "9.0.1"


### PR DESCRIPTION
The goal is to provide components which allow documentation which is more use-focused, and allows the user to provide their context (e.g. Urls, device id etc.) which will then be reflected in the documentation.

The following two React components have been added:

* `<UserContextForm>` - Form to allow users to edit the values used in the docs
* `<UserContext>` - Component which will replace variable references with the user provided values

The user context values are saved in the user's local storage in the Web browser, so the values are persisted across sessions.

The new components are not yet used, however they will be used in a follow up PR in the source documentation.