### PR TITLE
fix: switch to usehooks-ts lib to fix build issue caused by accessing local storage during server side rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^9.0.1",
     "react-select": "^5.8.0",
-    "shell-quote": "^1.8.1"
+    "shell-quote": "^1.8.1",
+    "usehooks-ts": "^3.1.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.1.0",

--- a/src/components/UserContext/index.js
+++ b/src/components/UserContext/index.js
@@ -1,23 +1,23 @@
 import React from 'react';
 import CodeBlock from '@theme/CodeBlock';
-import { useLocalStorage } from "@uidotdev/usehooks";
+import { useReadLocalStorage } from 'usehooks-ts';
 
 export default function UserContext(props={}) {
   const {children={}, language="sh"} = props;
   // Common
-  const [deviceId] = useLocalStorage('DEVICE_ID', props.deviceId || 'tedge001');
+  const deviceId = useReadLocalStorage('DEVICE_ID', props.deviceId || 'tedge001');
 
   // Cumulocity IoT
-  const [c8yUrl] = useLocalStorage('C8Y_URL', props.c8yUrl || 'example.eu-latest.com');
-  const [c8yUser] = useLocalStorage('C8Y_USER', props.c8yUser || 'jimmy@thin-edge.com');
+  const c8yUrl = useReadLocalStorage('C8Y_URL', props.c8yUrl || 'example.eu-latest.com');
+  const c8yUser = useReadLocalStorage('C8Y_USER', props.c8yUser || 'jimmy@thin-edge.com');
 
   // AWS
-  const [awsUrl] = useLocalStorage('AWS_URL', props.awsUrl || 'b1a1agbpo20syc.iot.us-east-1.amazonaws.com');
-  const [awsRegion] = useLocalStorage('AWS_REGION', props.awsRegion || 'us-east-1');
-  const [awsAccountId] = useLocalStorage('AWS_ACCOUNT_ID', props.awsAccountId || '123456789012');
+  const awsUrl = useReadLocalStorage('AWS_URL', props.awsUrl || 'b1a1agbpo20syc.iot.us-east-1.amazonaws.com');
+  const awsRegion = useReadLocalStorage('AWS_REGION', props.awsRegion || 'us-east-1');
+  const awsAccountId = useReadLocalStorage('AWS_ACCOUNT_ID', props.awsAccountId || '123456789012');
 
   // Azure
-  const [azureUrl] = useLocalStorage('AZURE_URL', props.azureUrl || 'your-iot-hub-name.azure-devices.net');
+  const azureUrl = useReadLocalStorage('AZURE_URL', props.azureUrl || 'your-iot-hub-name.azure-devices.net');
 
   const code = `${children.props.children.props.children || children.props.children}`
     .replace(/\$DEVICE_ID/g, deviceId)

--- a/src/components/UserContextForm/index.js
+++ b/src/components/UserContextForm/index.js
@@ -1,12 +1,13 @@
 import React, { useEffect } from 'react';
-import { useLocalStorage } from "@uidotdev/usehooks";
+import { useLocalStorage } from 'usehooks-ts';
+import BrowserOnly from '@docusaurus/BrowserOnly';
 
 function generateName(prefix='', len=10) {
   const genRanHex = size => [...Array(size)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
   return prefix + genRanHex(len);
 }
 
-export default function UserContextForm(props={}) {
+function UserContextForm(props={}) {
   const {settings = ''} = props;
   const showKeys = `${settings}`.split(',');
 
@@ -124,3 +125,17 @@ export default function UserContextForm(props={}) {
     </div>
   );
 }
+
+// Wrap component in the BrowserOnly to prevent re-hydration issues
+// where the initial values from the local storage aren't accessible yet
+// which results in the values being ignored when the local storage becomes
+// available
+export default function UserContextFormBrowserOnly(props) {
+  return (
+    <BrowserOnly fallback={<div>Loading user context...</div>}>
+      {() => {
+        return <UserContextForm {...props} />;
+      }}
+    </BrowserOnly>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9009,6 +9009,13 @@ use-isomorphic-layout-effect@^1.1.2:
   resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
   integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
 
+usehooks-ts@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/usehooks-ts/-/usehooks-ts-3.1.0.tgz#156119f36efc85f1b1952616c02580f140950eca"
+  integrity sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==
+  dependencies:
+    lodash.debounce "^4.0.8"
+
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"


### PR DESCRIPTION
Fix an issue with the previous `<UserContext*>` components which resulted in the production builds failing.

Switched to using a different library that didn't have the same problem, and also wrapped the `<UserContextForm>` in the `<BrowserOnly>` component to prevent it rendering before the local storage is available (which is provides the persistence layer).