### PR TITLE
fix(user-context): pass title through to code block

### DIFF
--- a/src/components/UserContext/index.js
+++ b/src/components/UserContext/index.js
@@ -3,7 +3,7 @@ import CodeBlock from '@theme/CodeBlock';
 import { useReadLocalStorage } from 'usehooks-ts';
 
 export default function UserContext(props={}) {
-  const {children={}, language="sh"} = props;
+  const {children={}, language="sh", title=""} = props;
   // Common
   const deviceId = useReadLocalStorage('DEVICE_ID', props.deviceId || 'tedge001');
 
@@ -30,7 +30,7 @@ export default function UserContext(props={}) {
   ;
   return (
     <div>
-      <CodeBlock language={language} >
+      <CodeBlock language={language} title={title}>
           {code}
       </CodeBlock>
     </div>


### PR DESCRIPTION
Support passing the title through to the code block.

**Example**

````
<UserContext language="sh" title="Output">

```sh
c8y.url=$C8Y_URL
c8y.profiles.second.url=other.cumulocity.com
```

</UserContext>
````