### PR TITLE
docs: backport instructions to install from behind a http proxy

### DIFF
--- a/versioned_docs/version-1.5.0/.version
+++ b/versioned_docs/version-1.5.0/.version
@@ -1,1 +1,1 @@
-1.5.0-2-g33faee4f56 main
+1.5.0-4-gd79d041ac9 main

--- a/versioned_docs/version-1.5.0/install/index.md
+++ b/versioned_docs/version-1.5.0/install/index.md
@@ -24,6 +24,18 @@ curl -fsSL https://thin-edge.io/install.sh | sh -s
 wget -O - https://thin-edge.io/install.sh | sh -s
 ```
 
+If the device is in a network behind a HTTP Proxy, then you will need to set the `https_proxy` environment variable before installing %%te%%.
+
+```sh
+export https_proxy="http://<username>:<password>@<ip>:<port>"
+
+# Without authentication
+export https_proxy="http://127.0.0.1:8080"
+
+# With authentication
+export https_proxy="http://user:password@127.0.0.1:8080"
+```
+
 ### Update using a package manager
 
 %%te%% and its components can be updated by running the install.sh script again, or using the Linux package manager on your distribution.

--- a/versioned_docs/version-1.5.0/start/getting-started.md
+++ b/versioned_docs/version-1.5.0/start/getting-started.md
@@ -66,6 +66,18 @@ curl -fsSL https://thin-edge.io/install.sh | sh -s
 wget -O - https://thin-edge.io/install.sh | sh -s
 ```
 
+If the device is in a network behind a HTTP Proxy, then you will need to set the `https_proxy` environment variable before installing %%te%%.
+
+```sh
+export https_proxy="http://<username>:<password>@<ip>:<port>"
+
+# Without authentication
+export https_proxy="http://127.0.0.1:8080"
+
+# With authentication
+export https_proxy="http://user:password@127.0.0.1:8080"
+```
+
 After a successful installation, it is possible to use %%te%% via the CLI and use the tedge commands.
 
 :::info


### PR DESCRIPTION
Update the 1.5.0 doc snapshot to include instructions how users can install thin-edge.io if the device is sitting behind a http proxy.