### PR TITLE
refactor: update references from Cumulocity IoT to Cumulocity

### DIFF
--- a/src/components/UserContext/index.js
+++ b/src/components/UserContext/index.js
@@ -7,7 +7,7 @@ export default function UserContext(props={}) {
   // Common
   const deviceId = useReadLocalStorage('DEVICE_ID', props.deviceId || 'tedge001');
 
-  // Cumulocity IoT
+  // Cumulocity
   const c8yUrl = useReadLocalStorage('C8Y_URL', props.c8yUrl || 'example.eu-latest.com');
   const c8yUser = useReadLocalStorage('C8Y_USER', props.c8yUser || 'jimmy@thin-edge.com');
   const c8yProfileName = useReadLocalStorage('C8Y_PROFILE_NAME', props.c8yProfileName || 'second');

--- a/src/components/UserContextForm/index.js
+++ b/src/components/UserContextForm/index.js
@@ -15,7 +15,7 @@ function UserContextForm(props={}) {
   const [deviceId, setDeviceId] = useLocalStorage('DEVICE_ID', props.deviceId || generateName('tedge_'));
   useEffect(() => setDeviceId(deviceId), [deviceId]);
 
-  // Cumulocity IoT
+  // Cumulocity
   const [c8yUrl, setC8yUrl] = useLocalStorage('C8Y_URL', props.c8yUrl || 'example.eu-latest.com');
   useEffect(() => updateUrl(c8yUrl), [c8yUrl]);
   const updateUrl = (url) => {
@@ -74,7 +74,7 @@ function UserContextForm(props={}) {
 
             <div className="row margin--xs" style={showStyle('C8Y_URL')}>
               <div className="col col--4">
-                <label htmlFor="c8y-url">Cumulocity IoT URL</label>
+                <label htmlFor="c8y-url">Cumulocity URL</label>
               </div>
               <div className="col col--6">
                 <input id="c8y-url" inputMode="text" value={c8yUrl} onChange={(e) => updateUrl(e.target.value)}></input>
@@ -83,7 +83,7 @@ function UserContextForm(props={}) {
 
             <div className="row margin--xs" style={showStyle('C8Y_USER')}>
               <div className="col col--4">
-                <label htmlFor="c8y-user">Cumulocity IoT User</label>
+                <label htmlFor="c8y-user">Cumulocity User</label>
               </div>
               <div className="col col--6">
               <input id="c8y-user" inputMode="text" value={c8yUser} onChange={(e) => setC8yUser(e.target.value)}></input>
@@ -101,7 +101,7 @@ function UserContextForm(props={}) {
 
             <div className="row margin--xs" style={showStyle('C8Y_PROFILE_URL')}>
               <div className="col col--4">
-                <label htmlFor="c8y-profile-url">Second Cumulocity IoT URL</label>
+                <label htmlFor="c8y-profile-url">Second Cumulocity URL</label>
               </div>
               <div className="col col--6">
               <input id="c8y-profile-url" inputMode="text" value={c8yProfileUrl} onChange={(e) => setC8yProfileUrl(e.target.value)}></input>

--- a/src/data/plugins.tsx
+++ b/src/data/plugins.tsx
@@ -4,7 +4,7 @@ const TAGS = {
   BOOTSTRAP: 'Bootstrap',
   CONFIG: 'Configuration',
   CONTAINER: 'Container',
-  CUMULOCITY: 'Cumulocity IoT',
+  CUMULOCITY: 'Cumulocity',
   EXAMPLE: 'Example',
   IMAGE: 'Image',
   INIT_SYSTEM: 'Init Systems',
@@ -161,7 +161,7 @@ const PluginsList: IPlugin[] = [
     packageUrl:
       'https://github.com/thin-edge/thin-edge.io_examples/tree/main/opcua-solution',
     description:
-      'OPC UA Gateway example which uses the Cumulocity IoT [opcua-device-gateway](https://github.com/thin-edge/opcua-device-gateway-container) to connect to OPC UA Servers and thin-edge.io',
+      'OPC UA Gateway example which uses the Cumulocity [opcua-device-gateway](https://github.com/thin-edge/opcua-device-gateway-container) to connect to OPC UA Servers and thin-edge.io',
     tags: [TAGS.PROTOCOLS, TAGS.EXAMPLE],
   },
 
@@ -210,7 +210,7 @@ const PluginsList: IPlugin[] = [
   {
     name: 'c8y-tedge',
     description:
-      '[go-c8y-cli](https://goc8ycli.netlify.app/) extension to provide common utilities to help with bootstrapping thin-edge.io devices to Cumulocity IoT',
+      '[go-c8y-cli](https://goc8ycli.netlify.app/) extension to provide common utilities to help with bootstrapping thin-edge.io devices to Cumulocity',
     sourceUrl: 'https://github.com/thin-edge/c8y-tedge',
     packageUrl: 'https://github.com/thin-edge/c8y-tedge',
     tags: [TAGS.TOOL, TAGS.BOOTSTRAP],
@@ -248,7 +248,7 @@ const PluginsList: IPlugin[] = [
   {
     name: 'cumulocity-remote-access-cloud-http-proxy',
     description:
-      'A Cumulocity IoT microservice that allows to proxy HTTP requests through the cloud to an HTTP server running on a Cumulocity IoT connected device',
+      'A Cumulocity microservice that allows to proxy HTTP requests through the cloud to an HTTP server running on a Cumulocity connected device',
     sourceUrl:
       'https://github.com/Cumulocity-IoT/cumulocity-remote-access-cloud-http-proxy',
     packageUrl:


### PR DESCRIPTION
There are still several usage of the old product name "Cumulocity IoT". This PR replace them with "Cumulocity".

**Example change:**
Before:
<img width="1002" height="561" alt="image" src="https://github.com/user-attachments/assets/8a5e5783-b027-48dd-b7b8-8905f0046e4e" />

After:
<img width="988" height="545" alt="image" src="https://github.com/user-attachments/assets/b4690226-f850-408f-91a1-683bc914972e" />
